### PR TITLE
python roctx with rocprofv3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.so
+__pycache__
+*.pftrace

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Step 3: Get the roctx trace using rocprof
  rocprofv3 --marker-trace --output-format pftrace -- python roctx_example.py
 ```
 
-Step 4: Copy the **rocprof_output/results.json** file to your system and visualize in [Perfetto](https://ui.perfetto.dev/)
+Step 4: Copy the **pftrace** file to your system and visualize in [Perfetto](https://ui.perfetto.dev/)

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ Example: Using roctx calls within a Python program
 
 Step 1: Compile the hip_code library
 ```
-module load rocm/6.0.0
+module load rocm
 make
 ```
+This will create `libHIPcode.so` which is used in the python code downstream.
+
 
 Step 2: Run the script to make sure it works
 ```
@@ -16,7 +18,7 @@ python3 roctx_example.py
 
 Step 3: Get the roctx trace using rocprof
 ```
-rocprof --roctx-trace -d rocprof_output -o rocprof_output/results.csv python3 roctx_example.py
+ rocprofv3 --marker-trace --output-format pftrace -- python roctx_example.py
 ```
 
 Step 4: Copy the **rocprof_output/results.json** file to your system and visualize in [Perfetto](https://ui.perfetto.dev/)

--- a/hip_tools.cpp
+++ b/hip_tools.cpp
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <iostream>
-#include <roctx.h>
-#include <roctracer_ext.h>
+
+#include <rocprofiler-sdk-roctx/roctx.h>
 #include <hip/hip_runtime.h>
 
 #define CHECK(command) {   \
@@ -31,16 +31,23 @@ int set_device( int proc_id ) {
 
 }
 
-void start_roctracer(){
-  roctracer_start();
+void start_roctracer(int tid){
+
+  roctxProfilerResume(tid);
+     //roctracer_start();
 }
 
-void stop_roctracer(){
-  roctracer_stop();
+int get_roctx_tid(){
+  auto tid = roctx_thread_id_t{};
+  roctxGetThreadId(&tid);
+  return tid;
+}
+
+void stop_roctracer(int tid){
+  roctxProfilerPause(tid);
 }
 
 int roctxr_start( char *c){
-  // std::cout << "Starting roctx marker: " << c << std::endl; 
   int id = roctxRangeStart(c);
   return id;
 }

--- a/hip_tools.py
+++ b/hip_tools.py
@@ -1,8 +1,18 @@
 
 encode = lambda s : s.encode('utf-8')
 
+# Needed so that we do not call start when already corresponding id is started
+roctx_ids_start = set()
+roctx_ids_stop = set()
+
 class HIP_tools:    
-  def __init__(self,  hip_lib_path):
+  
+  """
+  @param {string} hip_lib_path: path to compiled libHIPcode.so
+  @param {bool} stop_on_it prevents starting of rocprof on initialization. Useful for profiling ML workloads
+
+  """
+  def __init__(self,  hip_lib_path, stop_on_init = True):
 
 
     from ctypes import cdll, c_int, c_char_p        
@@ -12,7 +22,7 @@ class HIP_tools:
     self._set_device = libhip.set_device
     self._set_device.argtypes = [ c_int ]
     self._set_device.resypes = c_int
-
+    self._get_tid = libhip.get_roctx_tid
     self._start_roctracer = libhip.start_roctracer
     self._stop_roctracer = libhip.stop_roctracer
     self._roctxr_push = libhip.roctxr_push
@@ -23,16 +33,27 @@ class HIP_tools:
     self._roctxr_start.argtypes = [ c_char_p ]
     self._roctxr_start.resypes = c_int 
     self._roctxr_stop.argtypes = [ c_int ]
+    if stop_on_init:
+        self.stop_roctracer()
   
 
   def set_device(self, device_id ):
     self._set_device(device_id)
 
   def start_roctracer(self):
-    self._start_roctracer()
+    tid = self._get_tid()
+    if(tid not in roctx_ids_start):
+      self._start_roctracer()
+      roctx_ids_start.add(tid)
+      roctx_ids_stop.discard(tid)
 
   def stop_roctracer(self):
-    self._stop_roctracer()   
+    tid = self._get_tid()
+    if(tid not in roctx_ids_stop):
+      self._stop_roctracer()
+      roctx_ids_stop.add(tid)
+      roctx_ids_start.discard(tid)
+         
 
   def start_marker( self, marker_name ):
     marker_id = self._roctxr_start( encode(marker_name) )

--- a/roctx_example.py
+++ b/roctx_example.py
@@ -11,7 +11,7 @@ work_dir = os.getcwd()
 hip_lib_path = f'{work_dir}/libHIPcode.so'
 
 # Initialize the roctracer tools
-hip_tools = HIP_tools( hip_lib_path )
+hip_tools = HIP_tools( hip_lib_path,True )
 
 if use_torch:
   if not torch.cuda.is_available():
@@ -25,7 +25,7 @@ else:
   print('Setting hip device 0')
   hip_tools.set_device(0)  
 
-
+hip_tools.start_roctracer()
 # Do some fun stuff
 id_init = hip_tools.start_marker('init')
 
@@ -33,18 +33,21 @@ nx, ny = 1024, 1024
 A = np.random.rand( nx, ny )
 B = np.random.rand( nx, ny )
 
-hip_tools.stop_marker(id_init)
-
-id_main = hip_tools.start_marker('main')
 
 n_iterations = 20
 for i in range(n_iterations):
-
+  
+  #Only profiling even number
+  if(i%2 == 0):
+    hip_tools.start_roctracer()
+  
   id_iter = hip_tools.start_marker(f'iter_{i}')
   print( f'iteration: {i}')
   C = np.matmul(A, B)
 
   hip_tools.stop_marker(id_iter)
 
+  if(i%2 == 0):
+    hip_tools.stop_roctracer()
+
 print('Finished successfully')
-hip_tools.stop_marker(id_main)


### PR DESCRIPTION
Features:
1. Ability to prevent rocprofv3 to start profiling from start. Helpful with different ML workloads.
2. Updated to use rocprofv3. Tested on MI300X, MI355X with LLAMA2 70B inference.